### PR TITLE
Use $eval instead of $apply in loadTemplate()

### DIFF
--- a/ocLazyLoad.js
+++ b/ocLazyLoad.js
@@ -155,7 +155,7 @@
 			return {
 				link: function(scope, element, attr) {
 					var childScope;
-					var onloadExp = attr.onload || '';
+					var onloadExp = scope.$eval(attr.ocLazyLoad).onload || '';
 					
 					/**
 					 * Destroy the current scope of this element and empty the html


### PR DESCRIPTION
the current loadTemplate() can't be used in the callback of load() because of the scope.$apply() phase check
