### PR TITLE
Fixed: runBlocks can now have $templateCache arguments (now also works with the example project)

### DIFF
--- a/example/ocLazyLoad.js
+++ b/example/ocLazyLoad.js
@@ -10,284 +10,290 @@
 	var ocLazyLoad = angular.module('oc.lazyLoad', ['ng']);
 
 	ocLazyLoad.provider('$ocLazyLoad', ['$controllerProvider', '$provide', '$compileProvider', '$filterProvider', '$injector',
-        function($controllerProvider, $provide, $compileProvider, $filterProvider, $injector) {
+	                                    function($controllerProvider, $provide, $compileProvider, $filterProvider, $injector) {
 
-            var modules = {},
-                asyncLoader,
-	            templates = [],
-                providers = {
-                    $controllerProvider: $controllerProvider,
-                    $compileProvider: $compileProvider,
-                    $filterProvider: $filterProvider,
-                    $provide: $provide, // other things
-                    $injector: $injector
-                };
+		                                    var modules = {},
+			                                    asyncLoader,
+			                                    templates = [],
+			                                    providers = {
+				                                    $controllerProvider: $controllerProvider,
+				                                    $compileProvider: $compileProvider,
+				                                    $filterProvider: $filterProvider,
+				                                    $provide: $provide, // other things
+				                                    $injector: $injector
+			                                    };
 
-            this.$get = ['$timeout', '$log', '$q', '$templateCache', '$http', function($timeout, $log, $q, $templateCache, $http) {
-                return {
-                    getModuleConfig: function(name) {
-                        if(!modules[name]) {
-                            return null;
-                        }
-                        return modules[name];
-                    },
+		                                    this.$get = ['$timeout', '$log', '$q', '$templateCache', '$http', '$rootElement', function($timeout, $log, $q, $templateCache, $http, $rootElement) {
+												var instanceInjector;
+												//Make this lazy because at the moment that $get() is called the instance
+												//injector hasn't been assigned to the rootElement yet:
+												providers.getInstanceInjector = function() {
+													return (instanceInjector) ? instanceInjector : (instanceInjector = $rootElement.data('$injector'));
+												}
+			                                    return {
+				                                    getModuleConfig: function(name) {
+					                                    if(!modules[name]) {
+						                                    return null;
+					                                    }
+					                                    return modules[name];
+				                                    },
 
-                    setModuleConfig: function(module) {
-                        modules[module.name] = module;
-                        return module;
-                    },
+				                                    setModuleConfig: function(module) {
+					                                    modules[module.name] = module;
+					                                    return module;
+				                                    },
 
-                    getModules: function() {
-                        return regModules;
-                    },
+				                                    getModules: function() {
+					                                    return regModules;
+				                                    },
 
-                    getModuleName: function (module) {
-                        var moduleName;
-                        if (typeof module === 'string') {
-                            moduleName = module;
-                        } else if (typeof module === 'object' && module.hasOwnProperty('name') && typeof module.name === 'string') {
-                            moduleName = module.name;
-                        } else {
-                            moduleName = undefined;
-                        }
-                        return moduleName;
-                    },
+				                                    getModuleName: function (module) {
+					                                    var moduleName;
+					                                    if (typeof module === 'string') {
+						                                    moduleName = module;
+					                                    } else if (typeof module === 'object' && module.hasOwnProperty('name') && typeof module.name === 'string') {
+						                                    moduleName = module.name;
+					                                    } else {
+						                                    moduleName = undefined;
+					                                    }
+					                                    return moduleName;
+				                                    },
 
-	                loadTemplateFile: function(urls, config) {
-		                if(angular.isString(urls)) {
-			                urls = [urls];
-		                }
-		                var promisesList = [];
-		                angular.forEach(urls, function(url) {
-			                var deferred = $q.defer();
-			                promisesList.push(deferred.promise);
-			                if(templates.indexOf(url) === -1 || (angular.isDefined(config) && config.cache === false)) {
-				                $http.get(url, config).success(function(data) {
-					                angular.forEach(angular.element(data), function(node) {
-						                if(node.nodeName === 'SCRIPT' && node.type === 'text/ng-template') {
-							                $templateCache.put(node.id, node.innerHTML);
-						                }
-					                });
-					                templates.push(url);
-					                deferred.resolve();
-				                }).error(function(data) {
-					                $log.error('Error load template "' + url + "': " + data);
-				                });
-			                } else {
-				                deferred.resolve();
-			                }
-		                });
-		                return $q.all(promisesList);
-	                },
+				                                    loadTemplateFile: function(urls, config) {
+					                                    if(angular.isString(urls)) {
+						                                    urls = [urls];
+					                                    }
+					                                    var promisesList = [];
+					                                    angular.forEach(urls, function(url) {
+						                                    var deferred = $q.defer();
+						                                    promisesList.push(deferred.promise);
+						                                    if(templates.indexOf(url) === -1 || (angular.isDefined(config) && config.cache === false)) {
+							                                    $http.get(url, config).success(function(data) {
+								                                    angular.forEach(angular.element(data), function(node) {
+									                                    if(node.nodeName === 'SCRIPT' && node.type === 'text/ng-template') {
+										                                    $templateCache.put(node.id, node.innerHTML);
+									                                    }
+								                                    });
+								                                    templates.push(url);
+								                                    deferred.resolve();
+							                                    }).error(function(data) {
+								                                    $log.error('Error load template "' + url + '": ' + data);
+							                                    });
+						                                    } else {
+							                                    deferred.resolve();
+						                                    }
+					                                    });
+					                                    return $q.all(promisesList);
+				                                    },
 
-                    load: function(module) {
-                        var self = this,
-                            config = null,
-                            moduleCache = [],
-                            deferred = $q.defer(),
-                            moduleName,
-                            errText;
+				                                    load: function(module) {
+					                                    var self = this,
+						                                    config = null,
+						                                    moduleCache = [],
+						                                    deferred = $q.defer(),
+						                                    moduleName,
+						                                    errText;
 
-                        moduleName = self.getModuleName(module);
+					                                    moduleName = self.getModuleName(module);
 
-                        // If this module has been loaded before, re-use it.
-                        if (moduleExists(moduleName)) {
-                            moduleCache.push(moduleName);
-                            deferred.resolve();
-                            return deferred.promise;
-                        }
+					                                    // If this module has been loaded before, re-use it.
+					                                    if (moduleExists(moduleName)) {
+						                                    moduleCache.push(moduleName);
+						                                    deferred.resolve();
+						                                    return deferred.promise;
+					                                    }
 
-                        // Get or Set a configuration depending on what was passed in
-                        if (typeof module === 'string') {
-                            config = self.getModuleConfig(module);
-                        } else if (typeof module === 'object') {
-                            config = self.setModuleConfig(module);
-                        }
+					                                    // Get or Set a configuration depending on what was passed in
+					                                    if (typeof module === 'string') {
+						                                    config = self.getModuleConfig(module);
+					                                    } else if (typeof module === 'object') {
+						                                    config = self.setModuleConfig(module);
+					                                    }
 
-                        if (config === null) {
-                            errText = 'Module "' + moduleName + '" is not configured, cannot load.';
-                            $log.error(errText);
-                            throw errText;
-                        }
+					                                    if (config === null) {
+						                                    errText = 'Module "' + moduleName + '" is not configured, cannot load.';
+						                                    $log.error(errText);
+						                                    throw errText;
+					                                    }
 
-                        moduleCache.push = function (value) {
-                            if (this.indexOf(value) === -1) {
-                                Array.prototype.push.apply(this, arguments);
-                            }
-                        };
+					                                    moduleCache.push = function (value) {
+						                                    if (this.indexOf(value) === -1) {
+							                                    Array.prototype.push.apply(this, arguments);
+						                                    }
+					                                    };
 
-                        function loadDependencies(module) {
-                            var moduleName,
-                                loadedModule,
-                                requires,
-                                promisesList = [],
-                                load_complete;
+					                                    function loadDependencies(module) {
+						                                    var moduleName,
+							                                    loadedModule,
+							                                    requires,
+							                                    promisesList = [],
+							                                    load_complete;
 
-                            moduleName = self.getModuleName(module);
-                            loadedModule = angular.module(moduleName);
-                            requires = getRequires(loadedModule);
+						                                    moduleName = self.getModuleName(module);
+						                                    loadedModule = angular.module(moduleName);
+						                                    requires = getRequires(loadedModule);
 
-                            angular.forEach(requires, function (requireEntry) {
-                                var config,
-                                    deferredDep;
+						                                    angular.forEach(requires, function (requireEntry) {
+							                                    var config,
+								                                    deferredDep;
 
-                                // If no configuration is provided, try and find one from a previous load.
-                                // If there isn't one, bail and let the normal flow run
-                                if (typeof requireEntry === 'string') {
-                                    config = self.getModuleConfig(requireEntry);
-                                    if (config === null) {
-	                                    moduleCache.push(requireEntry); // We don't know about this module, but something else might, so push it anyway.
-	                                    return;
-                                    }
-                                    requireEntry = config;
-                                }
+							                                    // If no configuration is provided, try and find one from a previous load.
+							                                    // If there isn't one, bail and let the normal flow run
+							                                    if (typeof requireEntry === 'string') {
+								                                    config = self.getModuleConfig(requireEntry);
+								                                    if (config === null) {
+									                                    moduleCache.push(requireEntry); // We don't know about this module, but something else might, so push it anyway.
+									                                    return;
+								                                    }
+								                                    requireEntry = config;
+							                                    }
 
-                                // Check if this dependency has been loaded previously or is already in the moduleCache
-                                if (moduleExists(requireEntry.name) || moduleCache.indexOf(requireEntry.name) !== -1) {
-                                    if (typeof module !== 'string') {
-	                                    // The dependency exists, but it's being redefined, not inherited by a simple string reference, raise a warning and ignore the new config.
-	                                    // TODO: This could be made smarter. There's no checking here yet to determine if the configurations are actually different.
-	                                    $log.warn('Module "', moduleName, '" attempted to redefine configuration for dependency "', requireEntry.name, '"\nExisting:', self.getModuleConfig(requireEntry.name), 'Ignored:', requireEntry);
-                                    }
-                                    return;
-                                } else if (typeof requireEntry === 'object') {
-                                    // The dependency doesn't exist in the module cache and is a new conifguration, so store and push it.
-                                    self.setModuleConfig(requireEntry);
-                                    moduleCache.push(requireEntry.name);
-                                }
+							                                    // Check if this dependency has been loaded previously or is already in the moduleCache
+							                                    if (moduleExists(requireEntry.name) || moduleCache.indexOf(requireEntry.name) !== -1) {
+								                                    if (typeof module !== 'string') {
+									                                    // The dependency exists, but it's being redefined, not inherited by a simple string reference, raise a warning and ignore the new config.
+									                                    // TODO: This could be made smarter. There's no checking here yet to determine if the configurations are actually different.
+									                                    $log.warn('Module "', moduleName, '" attempted to redefine configuration for dependency "', requireEntry.name, '"\nExisting:', self.getModuleConfig(requireEntry.name), 'Ignored:', requireEntry);
+								                                    }
+								                                    return;
+							                                    } else if (typeof requireEntry === 'object') {
+								                                    // The dependency doesn't exist in the module cache and is a new conifguration, so store and push it.
+								                                    self.setModuleConfig(requireEntry);
+								                                    moduleCache.push(requireEntry.name);
+							                                    }
 
-                                // Check if the dependency has any files that need to be loaded. If there are, push a new promise to the promise list.
-                                if (requireEntry.hasOwnProperty('files') && requireEntry.files.length !== 0) {
-                                    deferredDep = $q.defer();
-                                    if (requireEntry.files) {
-	                                    promisesList.push(deferredDep.promise);
-	                                    asyncLoader(requireEntry.files, function () {
-		                                    loadDependencies(requireEntry).then(function () {
-			                                    deferredDep.resolve();
-		                                    });
-	                                    });
-                                    }
-                                }
-                            });
+							                                    // Check if the dependency has any files that need to be loaded. If there are, push a new promise to the promise list.
+							                                    if (requireEntry.hasOwnProperty('files') && requireEntry.files.length !== 0) {
+								                                    deferredDep = $q.defer();
+								                                    if (requireEntry.files) {
+									                                    promisesList.push(deferredDep.promise);
+									                                    asyncLoader(requireEntry.files, function () {
+										                                    loadDependencies(requireEntry).then(function () {
+											                                    deferredDep.resolve();
+										                                    });
+									                                    });
+								                                    }
+							                                    }
+						                                    });
 
-                            // Create a wrapper promise to watch the promise list and resolve it once everything is done.
-                            load_complete = $q.defer();
-                            $q.all(promisesList).then(function () {
-                                load_complete.resolve();
-                            });
+						                                    // Create a wrapper promise to watch the promise list and resolve it once everything is done.
+						                                    load_complete = $q.defer();
+						                                    $q.all(promisesList).then(function () {
+							                                    load_complete.resolve();
+						                                    });
 
-                            return load_complete.promise;
-                        }
+						                                    return load_complete.promise;
+					                                    }
 
-                        asyncLoader(config.files, function () {
-                            moduleCache.push(moduleName);
-                            loadDependencies(moduleName).then(function () {
-                                register(providers, moduleCache, $log);
-                                $timeout(function () {
-                                    deferred.resolve(config);
-                                });
-                            });
-                        });
+					                                    asyncLoader(config.files, function () {
+						                                    moduleCache.push(moduleName);
+						                                    loadDependencies(moduleName).then(function () {
+							                                    register(providers, moduleCache, $log);
+							                                    $timeout(function () {
+								                                    deferred.resolve(config);
+							                                    });
+						                                    });
+					                                    });
 
-                        return deferred.promise;
-                    }
-                };
-            }];
+					                                    return deferred.promise;
+				                                    }
+			                                    };
+		                                    }];
 
-            this.config = function(config) {
-	            if(typeof config.asyncLoader === 'undefined') {
-		            throw('You need to define an async loader such as requireJS or script.js');
-	            }
+		                                    this.config = function(config) {
+			                                    if(typeof config.asyncLoader === 'undefined') {
+				                                    throw('You need to define an async loader such as requireJS or script.js');
+			                                    }
 
-	            asyncLoader = config.asyncLoader;
-	            init(angular.element(window.document));
+			                                    asyncLoader = config.asyncLoader;
+			                                    init(angular.element(window.document));
 
-	            if(config.loadedModules) {
-		            var addRegModule = function(loadedModule) {
-			            if(regModules.indexOf(loadedModule) < 0) {
-				            regModules.push(loadedModule);
-				            angular.forEach(angular.module(loadedModule).requires, addRegModule);
-			            }
-		            }
-		            angular.forEach(config.loadedModules, addRegModule);
-	            }
+			                                    if(config.loadedModules) {
+				                                    var addRegModule = function(loadedModule) {
+					                                    if(regModules.indexOf(loadedModule) < 0) {
+						                                    regModules.push(loadedModule);
+						                                    angular.forEach(angular.module(loadedModule).requires, addRegModule);
+					                                    }
+				                                    };
+				                                    angular.forEach(config.loadedModules, addRegModule);
+			                                    }
 
-	            if(config.modules) {
-		            if(angular.isArray(config.modules)) {
-			            angular.forEach(config.modules, function(moduleConfig) {
-				            modules[moduleConfig.name] = moduleConfig;
-			            });
-		            } else {
-			            modules[config.modules.name] = config.modules;
-		            }
-	            }
-            };
-        }]);
+			                                    if(config.modules) {
+				                                    if(angular.isArray(config.modules)) {
+					                                    angular.forEach(config.modules, function(moduleConfig) {
+						                                    modules[moduleConfig.name] = moduleConfig;
+					                                    });
+				                                    } else {
+					                                    modules[config.modules.name] = config.modules;
+				                                    }
+			                                    }
+		                                    };
+	                                    }]);
 
 	ocLazyLoad.directive('ocLazyLoad', ['$http', '$log', '$ocLazyLoad', '$compile', '$timeout', '$templateCache',
-        function($http, $log, $ocLazyLoad, $compile, $timeout, $templateCache) {
-            return {
-                link: function(scope, element, attr) {
-                    var childScope;
-                    var onloadExp = scope.$eval(attr.ocLazyLoad).onload || '';
+	                                    function($http, $log, $ocLazyLoad, $compile, $timeout, $templateCache) {
+		                                    return {
+			                                    link: function(scope, element, attr) {
+				                                    var childScope;
+				                                    var onloadExp = scope.$eval(attr.ocLazyLoad).onload || '';
 
-                    /**
-                     * Destroy the current scope of this element and empty the html
-                     */
-                    function clearContent() {
-                        if(childScope) {
-                            childScope.$destroy();
-                            childScope = null;
-                        }
-                        element.html('');
-                    }
+				                                    /**
+				                                     * Destroy the current scope of this element and empty the html
+				                                     */
+				                                    function clearContent() {
+					                                    if(childScope) {
+						                                    childScope.$destroy();
+						                                    childScope = null;
+					                                    }
+					                                    element.html('');
+				                                    }
 
-                    /**
-                     * Load a template from cache or url
-                     * @param url
-                     * @param callback
-                     */
-                    function loadTemplate(url, callback) {
-                        var view;
+				                                    /**
+				                                     * Load a template from cache or url
+				                                     * @param url
+				                                     * @param callback
+				                                     */
+				                                    function loadTemplate(url, callback) {
+					                                    var view;
 
-                        if(typeof(view = $templateCache.get(url)) !== 'undefined') {
-                            callback(view);
-                        } else {
-                            $http.get(url)
-                                .success(function(data) {
-                                    $templateCache.put('view:' + url, data);
-                                    callback(data);
-                                })
-                                .error(function(data) {
-                                    $log.error('Error load template "' + url + "': " + data);
-                                });
-                        }
-                    }
+					                                    if(typeof(view = $templateCache.get(url)) !== 'undefined') {
+						                                    callback(view);
+					                                    } else {
+						                                    $http.get(url)
+							                                    .success(function(data) {
+								                                    $templateCache.put('view:' + url, data);
+								                                    callback(data);
+							                                    })
+							                                    .error(function(data) {
+								                                    $log.error('Error load template "' + url + '": ' + data);
+							                                    });
+					                                    }
+				                                    }
 
-                    scope.$watch(attr.ocLazyLoad, function(moduleName) {
-                        if(moduleName) {
-                            $ocLazyLoad.load(moduleName).then(function(moduleConfig) {
-                                if(!moduleConfig.template) {
-                                    return;
-                                }
-                                loadTemplate(moduleConfig.template, function(template) {
-                                    childScope = scope.$new();
-                                    element.html(template);
+				                                    scope.$watch(attr.ocLazyLoad, function(moduleName) {
+					                                    if(moduleName) {
+						                                    $ocLazyLoad.load(moduleName).then(function(moduleConfig) {
+							                                    if(!moduleConfig.template) {
+								                                    return;
+							                                    }
+							                                    loadTemplate(moduleConfig.template, function(template) {
+								                                    childScope = scope.$new();
+								                                    element.html(template);
 
-                                    var content = element.contents();
-                                    var linkFn = $compile(content);
-                                    linkFn(childScope);
-                                    childScope.$emit('$includeContentLoaded');
-                                    childScope.$eval(onloadExp);
-                                });
-                            });
-                        } else {
-                            clearContent();
-                        }
-                    });
-                }
-            };
-        }]);
+								                                    var content = element.contents();
+								                                    var linkFn = $compile(content);
+								                                    linkFn(childScope);
+								                                    childScope.$emit('$includeContentLoaded');
+								                                    childScope.$eval(onloadExp);
+							                                    });
+						                                    });
+					                                    } else {
+						                                    clearContent();
+					                                    }
+				                                    });
+			                                    }
+		                                    };
+	                                    }]);
 
 	/**
 	 * Get the list of required modules/services/... for this module
@@ -332,7 +338,10 @@
 			var i, ii, k, invokeQueue, moduleName, moduleFn, invokeArgs, provider, runBlocks = [];
 			for(k = registerModules.length - 1; k >= 0; k--) {
 				moduleName = registerModules[k];
-				if (regModules.indexOf(moduleName) > -1) {
+				if (typeof moduleName !== 'string') {
+					moduleName = getModuleName(moduleName);
+				}
+				if ((!moduleName) || (regModules.indexOf(moduleName) > -1)) {
 					continue;
 				}
 				regModules.push(moduleName);
@@ -341,12 +350,14 @@
 				try {
 					for(invokeQueue = moduleFn._invokeQueue, i = 0, ii = invokeQueue.length; i < ii; i++) {
 						invokeArgs = invokeQueue[i];
-						if(providers.hasOwnProperty(invokeArgs[0])) {
-							provider = providers[invokeArgs[0]];
-						} else {
-							return $log.error("unsupported provider " + invokeArgs[0]);
+						if (angular.isArray(invokeArgs)) {
+							if(providers.hasOwnProperty(invokeArgs[0])) {
+								provider = providers[invokeArgs[0]];
+							} else {
+								return $log.error('unsupported provider ' + invokeArgs[0]);
+							}
+							provider[invokeArgs[1]].apply(provider, invokeArgs[2]);
 						}
-						provider[invokeArgs[1]].apply(provider, invokeArgs[2]);
 					}
 				} catch(e) {
 					if(e.message) {
@@ -355,12 +366,13 @@
 					$log.error(e.message);
 					throw e;
 				}
-//				register(providers, moduleFn.requires, $log);
+				register(providers, moduleFn.requires, $log);
 				registerModules.pop();
 			}
+			var instanceInjector = providers.getInstanceInjector();
 			angular.forEach(runBlocks, function(fn) {
 				try {
-					angular.injector(['ng']).invoke(fn);
+					instanceInjector.invoke(fn);
 				} catch(e) {
 					if(e.message) {
 						e.message += ' from ' + moduleName;
@@ -370,6 +382,10 @@
 			});
 		}
 		return null;
+	}
+
+	function getModuleName(dependencyObject) {
+		return (dependencyObject.name) ? dependencyObject.name : null;
 	}
 
 	/**

--- a/ocLazyLoad.js
+++ b/ocLazyLoad.js
@@ -338,7 +338,10 @@
 			var i, ii, k, invokeQueue, moduleName, moduleFn, invokeArgs, provider, runBlocks = [];
 			for(k = registerModules.length - 1; k >= 0; k--) {
 				moduleName = registerModules[k];
-				if (regModules.indexOf(moduleName) > -1) {
+				if (typeof moduleName !== 'string') {
+					moduleName = getModuleName(moduleName);
+				}
+				if ((!moduleName) || (regModules.indexOf(moduleName) > -1)) {
 					continue;
 				}
 				regModules.push(moduleName);
@@ -379,6 +382,10 @@
 			});
 		}
 		return null;
+	}
+
+	function getModuleName(dependencyObject) {
+		return (dependencyObject.name) ? dependencyObject.name : null;
 	}
 
 	/**


### PR DESCRIPTION
As stated in the title, I've fixed the example project now.
It turns out that the .requires list isn't always just a list of moduleNames, but can contain objects as well.
I've taken that into cosnideration now. Both my test project and the example project work.
I think its solid now ;)
