### PR TITLE
Fixes for 0.3.0 Issue #38 and maybe #35

### DIFF
--- a/src/ocLazyLoad.js
+++ b/src/ocLazyLoad.js
@@ -393,9 +393,8 @@
                                             return self.getModuleConfig(requireEntry.name).files.indexOf(n) < 0
                                         });
                                         if (diff.length !== 0) {
-
                                             $log.warn('Module "', moduleName, '" attempted to redefine configuration for dependency. "', requireEntry.name, '"\n Additional Files Loaded:', diff);
-                                            promisesList.push(filesLoader(diff).then(function () {
+                                            promisesList.push(filesLoader(diff, params).then(function () {
                                                 return loadDependencies(requireEntry);
                                             }));
                                         }


### PR DESCRIPTION
- Small change to fix trailing commas in $ocLazyLoad.load([]) arrays. 
- Fixes duplicate load of JS/CSS/Templates in certain circumstances
- Fixes a css loading issue when 'cache' is not defined
-  Adds more robustness (and an optional warning) checking if a module is being defined differently in two locations and loads any additional files as required.
