### PR TITLE
FIx Error:[$compile:multidir] Multiple directives

### DIFF
--- a/src/ocLazyLoad.js
+++ b/src/ocLazyLoad.js
@@ -760,7 +760,7 @@
 				}
 			});
 		} else {
-			return true;
+			return false;
 		}
 		return newInvoke;
 	}


### PR DESCRIPTION
When app load own module directives  and lazyload own module controller javascript file at $stateProvider , ocLazyLoad make multiple directive load. To prevent it , I modified registerInvokeList function. 
- Error Message
  Error: [$compile:multidir] Multiple directives [sample, sample] asking for template on: <sample>
- Sample Code to reproduce error 
  https://github.com/takeshi/lazyload-sample
