### PR TITLE
PR for #93: Param to indicate file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ $ocLazyLoad.load({
 });
 ```
 
+Load a single module with multiple files and specify a type where necessary:
+Note: When using the requireJS style formatting, do not specify a file extension. Use one or the other.
+```js
+$ocLazyLoad.load({
+	name: 'TestModule',
+	files: [
+	    'testModule.js',
+	    {type: 'css', path: 'testModuleCtrl'},
+	    {type: 'html', path: 'testModuleCtrl.html'},
+	    {type: 'js', path: 'testModuleCtrl'},
+	    'js!testModuleService',
+	    'less!testModuleLessFile'
+	]
+});
+```
+
 Load multiple modules with one or more files:
 ```js
 $ocLazyLoad.load([{

--- a/src/ocLazyLoad.js
+++ b/src/ocLazyLoad.js
@@ -258,13 +258,18 @@
           angular.extend(params || {}, config);
 
           var pushFile = function(path) {
+            var file_type = null;
+            if (typeof path === 'object') {
+                file_type = path.type;
+                path = path.path;
+            }
             cachePromise = filesCache.get(path);
             if(angular.isUndefined(cachePromise) || params.cache === false) {
-              if(/\.(css|less)[^\.]*$/.test(path) && cssFiles.indexOf(path) === -1) {
+              if(file_type === 'css' || /\.(css|less)[^\.]*$/.test(path) && cssFiles.indexOf(path) === -1) {
                 cssFiles.push(path);
-              } else if(/\.(htm|html)[^\.]*$/.test(path) && templatesFiles.indexOf(path) === -1) {
+              } else if(file_type === 'html' || /\.(htm|html)[^\.]*$/.test(path) && templatesFiles.indexOf(path) === -1) {
                 templatesFiles.push(path);
-              } else if(jsFiles.indexOf(path) === -1) {
+              } else if(file_type === 'js' || jsFiles.indexOf(path) === -1) {
                 jsFiles.push(path);
               }
             } else if(cachePromise) {

--- a/src/ocLazyLoad.js
+++ b/src/ocLazyLoad.js
@@ -161,7 +161,7 @@
           }
 
           return deferred.promise;
-        }
+        };
 
         if(angular.isUndefined(jsLoader)) {
           /**
@@ -182,7 +182,7 @@
             }, function error(err) {
               callback(err);
             });
-          }
+          };
           jsLoader.ocLazyLoadLoader = true;
         }
 
@@ -205,7 +205,7 @@
             }, function error(err) {
               callback(err);
             });
-          }
+          };
           cssLoader.ocLazyLoadLoader = true;
         }
 
@@ -244,7 +244,7 @@
             }, function error(err) {
               callback(err);
             });
-          }
+          };
           templatesLoader.ocLazyLoadLoader = true;
         }
 
@@ -258,24 +258,43 @@
           angular.extend(params || {}, config);
 
           var pushFile = function(path) {
-            var file_type = null;
+            var file_type = null, m;
             if (typeof path === 'object') {
                 file_type = path.type;
                 path = path.path;
             }
             cachePromise = filesCache.get(path);
             if(angular.isUndefined(cachePromise) || params.cache === false) {
-              if(file_type === 'css' || /\.(css|less)[^\.]*$/.test(path) && cssFiles.indexOf(path) === -1) {
+
+                // Note that the code below won't cope with a file that has both types of definition.
+                // To fix this, the order of the comparisons could be reversed, but it would mean forcing two
+                // regexp compares for each load "just in case" someone was using the more obscure method.
+
+              if (!file_type) {
+                if ((m = /[.](css|less|html|htm|js)?$/.exec(path)) != null) {  // Detect file type via file extension
+                    file_type = m[1];
+                } else if ((m = /^(css|less|html|htm|js)?(?=!)/.exec(path)) != null) { // Detect file type using preceding type declaration (ala requireJS)
+                    file_type = m[1];
+                    path = path.substr(m[1].length + 1, path.length);  // Strip the type from the path
+                } else {
+                    $log.error('File type could not be determined. ' + path);
+                    return;
+                }
+              }
+
+              if((file_type === 'css' || file_type === 'less') && cssFiles.indexOf(path) === -1) {
                 cssFiles.push(path);
-              } else if(file_type === 'html' || /\.(htm|html)[^\.]*$/.test(path) && templatesFiles.indexOf(path) === -1) {
+              } else if ((file_type === 'html' || file_type === 'htm') && templatesFiles.indexOf(path) === -1) {
                 templatesFiles.push(path);
-              } else if(file_type === 'js' || jsFiles.indexOf(path) === -1) {
+              } else if((file_type === 'js') || jsFiles.indexOf(path) === -1) {
                 jsFiles.push(path);
+              } else {
+                  $log.error('File type is not valid. ' + path);
               }
             } else if(cachePromise) {
               promises.push(cachePromise);
             }
-          }
+          };
 
           if(params.serie) {
             pushFile(params.files.shift());
@@ -331,7 +350,7 @@
           } else {
             return $q.all(promises);
           }
-        }
+        };
 
         return {
           /**

--- a/tests/unit/lazyLoad/test.NoExtCss
+++ b/tests/unit/lazyLoad/test.NoExtCss
@@ -1,0 +1,3 @@
+body {
+  background: #111;
+}

--- a/tests/unit/lazyLoad/testModule.NoExtension
+++ b/tests/unit/lazyLoad/testModule.NoExtension
@@ -20,17 +20,17 @@ testModuleNoExt.run(function() {
 });
 
 // controllers
-testModuleNoExt.controller('TestCtrl', function($scope) {
+testModuleNoExt.controller('TestCtrlNoExt', function($scope) {
   spy.ctrl('ctrl');
 });
 
 //
-testModuleNoExt.factory('testService', [function () {
+testModuleNoExt.factory('testServiceNoExt', [function () {
   spy.service('service');
   return {};
 }]);
 
-testModuleNoExt.filter('testFilter', function () {
+testModuleNoExt.filter('testFilterNoExt', function () {
   spy.filter('filter');
   return function (input) {
     return input;

--- a/tests/unit/lazyLoad/testModule.NoExtension
+++ b/tests/unit/lazyLoad/testModule.NoExtension
@@ -1,43 +1,43 @@
 // ngGrid is also lazy loaded by $ocLazyLoad thanks to the module dependency injection !
-var testModule = angular.module('testModule', []);
+var testModuleNoExt = angular.module('testModuleNoExt', []);
 
 // config blocks
-testModule.config(function() {
+testModuleNoExt.config(function() {
   spy.config('config1');
 });
 
-testModule.config(function() {
+testModuleNoExt.config(function() {
   spy.config('config2');
 });
 
 // run blocks
-testModule.run(function() {
+testModuleNoExt.run(function() {
   spy.run('run1');
 });
 
-testModule.run(function() {
+testModuleNoExt.run(function() {
   spy.run('run2');
 });
 
 // controllers
-testModule.controller('TestCtrlNoExt', function($scope) {
+testModuleNoExt.controller('TestCtrl', function($scope) {
   spy.ctrl('ctrl');
 });
 
 //
-testModule.factory('testServiceNoExt', [function () {
+testModuleNoExt.factory('testService', [function () {
   spy.service('service');
   return {};
 }]);
 
-testModule.filter('testFilterNoExt', function () {
+testModuleNoExt.filter('testFilter', function () {
   spy.filter('filter');
   return function (input) {
     return input;
   }
 });
 
-testModule.directive("test", function () {
+testModuleNoExt.directive("testNoExt", function () {
   spy.directive('directive');
   return {
     restrict: 'E',
@@ -47,7 +47,7 @@ testModule.directive("test", function () {
 });
 
 // redefine directive to check that both won't be invoked (it would throw a [$compile:multidir] Multiple directives)
-testModule.directive("test", function () {
+testModuleNoExt.directive("testNoExt", function () {
   spy.directive('directive');
   return {
     restrict: 'E',

--- a/tests/unit/lazyLoad/testModule.js
+++ b/tests/unit/lazyLoad/testModule.js
@@ -20,17 +20,17 @@ testModule.run(function() {
 });
 
 // controllers
-testModule.controller('TestCtrlNoExt', function($scope) {
+testModule.controller('TestCtrl', function($scope) {
   spy.ctrl('ctrl');
 });
 
 //
-testModule.factory('testServiceNoExt', [function () {
+testModule.factory('testService', [function () {
   spy.service('service');
   return {};
 }]);
 
-testModule.filter('testFilterNoExt', function () {
+testModule.filter('testFilter', function () {
   spy.filter('filter');
   return function (input) {
     return input;

--- a/tests/unit/specs/ocLazyLoad.spec.js
+++ b/tests/unit/specs/ocLazyLoad.spec.js
@@ -153,7 +153,7 @@ describe('Module: oc.lazyLoad', function() {
                   name: 'testModuleNoExt',
                   files: [
                       {type: 'js', file: lazyLoadUrl + 'testModule.NoExtension'},
-                      'css!' + lazyLoadUrl + 'test.css',
+                      'css!' + lazyLoadUrl + 'test.NoExtCss',
                       templateUrl
                   ]
               };

--- a/tests/unit/specs/ocLazyLoad.spec.js
+++ b/tests/unit/specs/ocLazyLoad.spec.js
@@ -153,6 +153,7 @@ describe('Module: oc.lazyLoad', function() {
                   name: 'testModuleNoExt',
                   files: [
                       {type: 'js', file: lazyLoadUrl + 'testModule.NoExtension'},
+                      lazyLoadUrl + 'test.css',
                       'css!' + lazyLoadUrl + 'test.NoExtCss',
                       templateUrl
                   ]

--- a/tests/unit/specs/ocLazyLoad.spec.js
+++ b/tests/unit/specs/ocLazyLoad.spec.js
@@ -146,6 +146,61 @@ describe('Module: oc.lazyLoad', function() {
       });
     });
 
+    it('should be able to lazy load a module when specifying a file type', function(done) {
+          var interval = triggerDigests(),
+              templateUrl = lazyLoadUrl + 'test.html',
+              testModule = {
+                  name: 'testModuleNoExt',
+                  files: [
+                      {type: 'js', file: lazyLoadUrl + 'testModule.NoExtension'},
+                      'css!' + lazyLoadUrl + 'test.css',
+                      templateUrl
+                  ]
+              };
+
+          // create spies for the following tests
+          window.spy = jasmine.createSpyObj('spy', ['config', 'run', 'ctrl', 'service', 'filter', 'directive']);
+
+          $ocLazyLoad.load(testModule).then(function success(res){
+              window.clearInterval(interval);
+
+              // Test the module loading
+              expect(res).toEqual(testModule);
+              expect(function() { angular.module('testModuleNoExt') }).not.toThrow();
+              expect(angular.module('testModuleNoExt')).toBeDefined();
+
+              // execute controller
+              $controller('TestCtrlNoExt', { $scope: $rootScope.$new() });
+
+              // instantiate service
+              $injector.get('testServiceNoExt');
+
+              // execute filter
+              $filter('testFilterNoExt');
+
+              // Compile a piece of HTML containing the directive
+              element = $compile("<test-no-ext></test-no-ext>")($rootScope.$new());
+
+              // Test the template loading
+              var $templateCache = $injector.get('$templateCache');
+              expect($templateCache.get('/partials/test.html')).toEqual('Test partial content');
+
+              // Test the css loading
+              var links = document.getElementsByTagName('link');
+              expect(links.length).toBeGreaterThan(0);
+              expect(function() { links[links.length - 1].sheet.cssRules; }).not.toThrow(); // this only works if a stylesheet has been loaded
+              expect(links[links.length - 1].sheet.cssRules).toBeDefined();
+
+              // because debug is set to false, we shouldn't have any log
+              $log.assertEmpty();
+
+              done();
+          }, function error(err){
+              window.clearInterval(interval);
+              throw err;
+          });
+      });
+
     it('should be able to execute config blocks', function() {
       expect(window.spy.config).toHaveBeenCalledWith('config1');
       expect(window.spy.config).toHaveBeenCalledWith('config2');

--- a/tests/unit/specs/ocLazyLoad.spec.js
+++ b/tests/unit/specs/ocLazyLoad.spec.js
@@ -149,7 +149,7 @@ describe('Module: oc.lazyLoad', function() {
     it('should be able to lazy load a module when specifying a file type', function(done) {
           var interval = triggerDigests(),
               templateUrl = lazyLoadUrl + 'test.html',
-              testModule = {
+              testModuleNoExt = {
                   name: 'testModuleNoExt',
                   files: [
                       {type: 'js', file: lazyLoadUrl + 'testModule.NoExtension'},
@@ -161,11 +161,11 @@ describe('Module: oc.lazyLoad', function() {
           // create spies for the following tests
           window.spy = jasmine.createSpyObj('spy', ['config', 'run', 'ctrl', 'service', 'filter', 'directive']);
 
-          $ocLazyLoad.load(testModule).then(function success(res){
+          $ocLazyLoad.load(testModuleNoExt).then(function success(res){
               window.clearInterval(interval);
 
               // Test the module loading
-              expect(res).toEqual(testModule);
+              expect(res).toEqual(testModuleNoExt);
               expect(function() { angular.module('testModuleNoExt') }).not.toThrow();
               expect(angular.module('testModuleNoExt')).toBeDefined();
 

--- a/tests/unit/specs/ocLazyLoad.spec.js
+++ b/tests/unit/specs/ocLazyLoad.spec.js
@@ -146,61 +146,6 @@ describe('Module: oc.lazyLoad', function() {
       });
     });
 
-    it('should be able to lazy load a module when specifying a file type', function(done) {
-          var interval = triggerDigests(),
-              templateUrl = lazyLoadUrl + 'test.html',
-              testModuleNoExt = {
-                  name: 'testModuleNoExt',
-                  files: [
-                      {type: 'js', file: lazyLoadUrl + 'testModule.NoExtension'},
-                      'css!' + lazyLoadUrl + 'test.NoExtCss',
-                      templateUrl
-                  ]
-              };
-
-          // create spies for the following tests
-          window.spy = jasmine.createSpyObj('spy', ['config', 'run', 'ctrl', 'service', 'filter', 'directive']);
-
-          $ocLazyLoad.load(testModuleNoExt).then(function success(res){
-              window.clearInterval(interval);
-
-              // Test the module loading
-              expect(res).toEqual(testModuleNoExt);
-              expect(function() { angular.module('testModuleNoExt') }).not.toThrow();
-              expect(angular.module('testModuleNoExt')).toBeDefined();
-
-              // execute controller
-              $controller('TestCtrlNoExt', { $scope: $rootScope.$new() });
-
-              // instantiate service
-              $injector.get('testServiceNoExt');
-
-              // execute filter
-              $filter('testFilterNoExt');
-
-              // Compile a piece of HTML containing the directive
-              element = $compile("<test-no-ext></test-no-ext>")($rootScope.$new());
-
-              // Test the template loading
-              var $templateCache = $injector.get('$templateCache');
-              expect($templateCache.get('/partials/test.html')).toEqual('Test partial content');
-
-              // Test the css loading
-              var links = document.getElementsByTagName('link');
-              expect(links.length).toBeGreaterThan(0);
-              expect(function() { links[links.length - 1].sheet.cssRules; }).not.toThrow(); // this only works if a stylesheet has been loaded
-              expect(links[links.length - 1].sheet.cssRules).toBeDefined();
-
-              // because debug is set to false, we shouldn't have any log
-              $log.assertEmpty();
-
-              done();
-          }, function error(err){
-              window.clearInterval(interval);
-              throw err;
-          });
-      });
-
     it('should be able to execute config blocks', function() {
       expect(window.spy.config).toHaveBeenCalledWith('config1');
       expect(window.spy.config).toHaveBeenCalledWith('config2');

--- a/tests/unit/specs/ocLazyLoad.spec.js
+++ b/tests/unit/specs/ocLazyLoad.spec.js
@@ -146,6 +146,61 @@ describe('Module: oc.lazyLoad', function() {
       });
     });
 
+    it('should be able to lazy load a module when specifying a file type', function(done) {
+          var interval = triggerDigests(),
+              templateUrl = lazyLoadUrl + 'test.html',
+              testModuleNoExt = {
+                  name: 'testModuleNoExt',
+                  files: [
+                      {type: 'js', file: lazyLoadUrl + 'testModule.NoExtension'},
+                      'css!' + lazyLoadUrl + 'test.NoExtCss',
+                      templateUrl
+                  ]
+              };
+
+          // create spies for the following tests
+          window.spy = jasmine.createSpyObj('spy', ['config', 'run', 'ctrl', 'service', 'filter', 'directive']);
+
+          $ocLazyLoad.load(testModuleNoExt).then(function success(res){
+              window.clearInterval(interval);
+
+              // Test the module loading
+              expect(res).toEqual(testModuleNoExt);
+              expect(function() { angular.module('testModuleNoExt') }).not.toThrow();
+              expect(angular.module('testModuleNoExt')).toBeDefined();
+
+              // execute controller
+              $controller('TestCtrlNoExt', { $scope: $rootScope.$new() });
+
+              // instantiate service
+              $injector.get('testServiceNoExt');
+
+              // execute filter
+              $filter('testFilterNoExt');
+
+              // Compile a piece of HTML containing the directive
+              element = $compile("<test-no-ext></test-no-ext>")($rootScope.$new());
+
+              // Test the template loading
+              var $templateCache = $injector.get('$templateCache');
+              expect($templateCache.get('/partials/test.html')).toEqual('Test partial content');
+
+              // Test the css loading
+              var links = document.getElementsByTagName('link');
+              expect(links.length).toBeGreaterThan(0);
+              expect(function() { links[links.length - 1].sheet.cssRules; }).not.toThrow(); // this only works if a stylesheet has been loaded
+              expect(links[links.length - 1].sheet.cssRules).toBeDefined();
+
+              // because debug is set to false, we shouldn't have any log
+              $log.assertEmpty();
+
+              done();
+          }, function error(err){
+              window.clearInterval(interval);
+              throw err;
+          });
+      });
+
     it('should be able to execute config blocks', function() {
       expect(window.spy.config).toHaveBeenCalledWith('config1');
       expect(window.spy.config).toHaveBeenCalledWith('config2');


### PR DESCRIPTION
* Added support for specifing the type of a file. Use files: [{path: 'path/to/file.x', type: 'type'}] where type is either css, html or js. Co-exists with regular path-only files entries. Small 8 line change to address #93  