### PR TITLE
Prevent PhantomJS to pass iOS6 Safari check

### DIFF
--- a/dist/ocLazyLoad.js
+++ b/dist/ocLazyLoad.js
@@ -145,7 +145,7 @@
               } else if(ua.indexOf("android") > -1) { // Android < 4.4
                 var androidVersion = parseFloat(ua.slice(ua.indexOf("android") + 8));
                 useCssLoadPatch = androidVersion < 4.4;
-              } else if(ua.indexOf('safari') > -1 && ua.indexOf('chrome') == -1) {
+              } else if(ua.indexOf('safari') > -1 && ua.indexOf('chrome') == -1 && ua.indexOf('phantomjs') == -1) {
                 var safariVersion = parseFloat(ua.match(/version\/([\.\d]+)/i)[1]);
                 useCssLoadPatch = safariVersion < 6;
               }


### PR DESCRIPTION
PhantomJS has the following UserAgent string `Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) PhantomJS/2.0.0 (development) Safari/538.1`. The check for iOS6 Safari returns `true` for this string. The function later fails on `ua.match(/version\/([\.\d]+)/i)`. This change prevents PhantomJS UserAgent string to pass the iOS6 Safari check.