### PR TITLE
point at unminified version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oclazyload",
   "version": "1.0.0-alpha1",
   "description": "Load modules on demand (lazy load) with angularJS",
-  "main": "dist/ocLazyLoad.min.js",
+  "main": "dist/ocLazyLoad.js",
   "author": "Olivier Combe <olivier.combe@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/ocombe/ocLazyLoad",


### PR DESCRIPTION
screenshot: http://take.ms/s7eWt

I've found that source mapping isn't really a great solution (yet). In chrome, 

1. It keeps the file in a different tree `/source` in devtools than the actual source code.
2. I can't seem to set debug lines for files in the `/source` tree. Yes, I've turned on JS sourcemaps support, otherwise this file wouldn't be loaded in the screenshot at all.

The reality is that if I want the minified version, my build system will handle it just fine.

I know this may be a contentious change. You can reject this PR if you want.