### PR TITLE
Send a copy of the global config instead of the reference.

### DIFF
--- a/src/ocLazyLoad.core.js
+++ b/src/ocLazyLoad.core.js
@@ -387,7 +387,7 @@
                     if(!modules[moduleName]) {
                         return null;
                     }
-                    return modules[moduleName];
+                    return angular.copy(modules[moduleName]);
                 },
 
                 /**


### PR DESCRIPTION
When we use serie config for a module, we shift element (https://github.com/ocombe/ocLazyLoad/blob/a9e624847934180e066dfad86cdc5f9e32cb3416/dist/modules/ocLazyLoad.loaders.core.js#L73) from the module and this affect the global params (because we are by reference and not value), with the copy, we only send value and not reference to the object, then we can modify him without impacting the global config

@rtrompier