### PR TITLE
fix(user-agent): guard against null-refs when parsing Safari user-agents

### DIFF
--- a/src/ocLazyLoad.loaders.common.js
+++ b/src/ocLazyLoad.loaders.common.js
@@ -93,9 +93,9 @@
                         } else if(ua.indexOf("android") > -1) { // Android < 4.4
                             var androidVersion = parseFloat(ua.slice(ua.indexOf("android") + 8));
                             useCssLoadPatch = androidVersion < 4.4;
-                        } else if(ua.indexOf('safari') > -1 && ua.indexOf('chrome') == -1 && ua.indexOf('phantomjs') == -1) {
-                            var safariVersion = parseFloat(ua.match(/version\/([\.\d]+)/i)[1]);
-                            useCssLoadPatch = safariVersion < 6;
+                        } else if(ua.indexOf('safari') > -1) {
+                            var versionMatch = ua.match(/version\/([\.\d]+)/i);
+                            useCssLoadPatch = (versionMatch && versionMatch[1] && parseFloat(versionMatch[1]) < 6);
                         }
                     }
 


### PR DESCRIPTION
the specific problematic user-agent that we ran into was googlebot's:

`AdsBot-Google-Mobile (+http://www.google.com/mobile/adsbot.html) Mozilla (iPhone; U; CPU iPhone OS 3 0 like Mac OS X) AppleWebKit (KHTML, like Gecko) Mobile Safari`

I removed the blacklisting of Chrome and PhantomJS from the conditional as neither have "version" anywhere in their agents, and the more generalized fix should catch them fine. 

Didn't produce dist assets, but can do so if needed. Likewise, let me know if you want any tweaks to the implementation.