### PR TITLE
fix: add extra condition to improve karma testing

### DIFF
--- a/src/ocLazyLoad.core.js
+++ b/src/ocLazyLoad.core.js
@@ -71,7 +71,7 @@
                     names[name] = true;
                     append(document.getElementById(name));
                     name = name.replace(':', '\\:');
-                    if(element[0].querySelectorAll) {
+                    if(typeof(element[0]) !== 'undefined' && element[0].querySelectorAll) {
                         angular.forEach(element[0].querySelectorAll(`.${ name }`), append);
                         angular.forEach(element[0].querySelectorAll(`.${ name }\\:`), append);
                         angular.forEach(element[0].querySelectorAll(`[${ name }]`), append);


### PR DESCRIPTION
Some of our unit tests fail when element is not defined.

`Error: [$injector:modulerr] Failed to instantiate module oc.lazyLoad due to:
	TypeError: Cannot read property 'querySelectorAll' of undefined`

I would really appreciate if you could release a version with this fix asap.
Thanks a lot