### PR TITLE
Fix for loading a module with dependencies with the oc-lazy-load directive

### DIFF
--- a/src/ocLazyLoad.core.js
+++ b/src/ocLazyLoad.core.js
@@ -24,7 +24,8 @@
             },
             debug = false,
             events = false,
-            moduleCache = [];
+            moduleCache = [],
+            modulePromises = {};
 
         moduleCache.push = function(value) {
             if(this.indexOf(value) === -1) {
@@ -572,6 +573,7 @@
                         var res = modulesToLoad.slice(); // clean copy
                         var loadNext = function loadNext(moduleName) {
                             moduleCache.push(moduleName);
+                            modulePromises[moduleName] = deferred.promise;
                             self._loadDependencies(moduleName, localParams).then(function success() {
                                 try {
                                     justLoaded = [];
@@ -594,6 +596,8 @@
 
                         // load the first in list
                         loadNext(modulesToLoad.shift());
+                    } else if (localParams && localParams.name && modulePromises[localParams.name]) {
+                        return modulePromises[localParams.name];
                     } else {
                         deferred.resolve();
                     }


### PR DESCRIPTION
There is a bug that happens when you try to inject into a page a module at more that one place using the oc-lazy-load directive. It only happens when the module you try to inject has some files dependencies declared.

I created a reduced test case in this Plunker: http://plnkr.co/edit/pAq7cneNylQmfCFHZV66

Not 100% sure if the solution is the best way to solve the problem nor if it will have some unwanted side effect. The unit tests pass successfully.