### PR TITLE
Fix infinite recursion when passing an array into `$ocLazyLoad.inject()`

### DIFF
--- a/src/ocLazyLoad.core.js
+++ b/src/ocLazyLoad.core.js
@@ -595,7 +595,7 @@
                         if(angular.isArray(moduleName)) {
                             var promisesList = [];
                             angular.forEach(moduleName, module => {
-                                promisesList.push(self.inject(moduleName, localParams, real));
+                                promisesList.push(self.inject(module, localParams, real));
                             });
                             return $q.all(promisesList);
                         } else {


### PR DESCRIPTION
Attempts to fix #252. Is this compatible with your changes in #242, @phenomnomnominal?