### PR TITLE
Wrapper for using  requireJS as JSLoader

### DIFF
--- a/src/ocLazyLoad.loaders.core.js
+++ b/src/ocLazyLoad.loaders.core.js
@@ -39,7 +39,7 @@
                         if(!file_type) {
                             if((m = /[.](css|less|html|htm|js)?((\?|#).*)?$/.exec(path)) !== null) {  // Detect file type via file extension
                                 file_type = m[1];
-                            } else if(!$delegate.jsLoader.hasOwnProperty('ocLazyLoadLoader') && $delegate.jsLoader.hasOwnProperty('load')) { // requirejs
+                            } else if(!$delegate.jsLoader.hasOwnProperty('ocLazyLoadLoader') && $delegate.jsLoader.hasOwnProperty('requirejs')) { // requirejs
                                 file_type = 'js';
                             } else {
                                 $delegate._$log.error(`File type could not be determined. ${ path }`);
@@ -99,7 +99,7 @@
                 if(jsFiles.length > 0) {
                     var jsDeferred = $q.defer();
                     $delegate.jsLoader(jsFiles, err => {
-                        if(angular.isDefined(err) && $delegate.jsLoader.hasOwnProperty('ocLazyLoadLoader')) {
+                        if(angular.isDefined(err) && ($delegate.jsLoader.hasOwnProperty("ocLazyLoadLoader") || $delegate.jsLoader.hasOwnProperty("requirejs"))) {
                             $delegate._$log.error(err);
                             jsDeferred.reject(err);
                         } else {

--- a/src/ocLazyLoad.loaders.requireJSLoader.js
+++ b/src/ocLazyLoad.loaders.requireJSLoader.js
@@ -11,7 +11,10 @@
              * @param params object config parameters
              * because the user can overwrite jsLoader and it will probably not use promises :(
              */
-            $delegate.jsLoader = require;
+            $delegate.jsLoader = function (paths, callback, params) {
+                require(paths, callback.bind(null, null), callback, params);
+            };
+            $delegate.jsLoader.requirejs = true;
 
             return $delegate;
         })


### PR DESCRIPTION
jsLoader callback param expects err as the first argument, but require()
has separate callbacks for success and error. Create a wrapper to
resolve conflict. Also add jsLoader.requirejs property for loaders.core
to determine filetype and errors
fixes #178 