### PR TITLE
Added error callBack to jsLoader call

### DIFF
--- a/dist/ocLazyLoad.require.js
+++ b/dist/ocLazyLoad.require.js
@@ -25,13 +25,13 @@
     ocLazyLoad.provider('$ocLazyLoad', ["$controllerProvider", "$provide", "$compileProvider", "$filterProvider", "$injector", "$animateProvider", function ($controllerProvider, $provide, $compileProvider, $filterProvider, $injector, $animateProvider) {
         var modules = {},
             providers = {
-            $controllerProvider: $controllerProvider,
-            $compileProvider: $compileProvider,
-            $filterProvider: $filterProvider,
-            $provide: $provide, // other things (constant, decorator, provider, factory, service)
-            $injector: $injector,
-            $animateProvider: $animateProvider
-        },
+                $controllerProvider: $controllerProvider,
+                $compileProvider: $compileProvider,
+                $filterProvider: $filterProvider,
+                $provide: $provide, // other things (constant, decorator, provider, factory, service)
+                $injector: $injector,
+                $animateProvider: $animateProvider
+            },
             debug = false,
             events = false,
             moduleCache = [],
@@ -75,8 +75,8 @@
                     names = ['ng:app', 'ng-app', 'x-ng-app', 'data-ng-app'],
                     NG_APP_CLASS_REGEXP = /\sng[:\-]app(:\s*([\w\d_]+);?)?\s/,
                     append = function append(elm) {
-                    return elm && elements.push(elm);
-                };
+                        return elm && elements.push(elm);
+                    };
 
                 angular.forEach(names, function (name) {
                     names[name] = true;
@@ -654,8 +654,8 @@
                                 if (modulesToLoad.length > 0) {
                                     loadNext(modulesToLoad.shift()); // load the next in list
                                 } else {
-                                        deferred.resolve(res); // everything has been loaded, resolve
-                                    }
+                                    deferred.resolve(res); // everything has been loaded, resolve
+                                }
                             }, function error(err) {
                                 deferred.reject(err);
                             });
@@ -812,16 +812,16 @@
                     loaded,
                     filesCache = $delegate._getFilesCache(),
                     cacheBuster = function cacheBuster(url) {
-                    var dc = new Date().getTime();
-                    if (url.indexOf('?') >= 0) {
-                        if (url.substring(0, url.length - 1) === '&') {
-                            return url + '_dc=' + dc;
+                        var dc = new Date().getTime();
+                        if (url.indexOf('?') >= 0) {
+                            if (url.substring(0, url.length - 1) === '&') {
+                                return url + '_dc=' + dc;
+                            }
+                            return url + '&_dc=' + dc;
+                        } else {
+                            return url + '?_dc=' + dc;
                         }
-                        return url + '&_dc=' + dc;
-                    } else {
-                        return url + '?_dc=' + dc;
-                    }
-                };
+                    };
 
                 // Store the promise early so the file load can be detected by other parallel lazy loads
                 // (ie: multiple routes on one page) a 'true' value isn't sufficient
@@ -1022,13 +1022,11 @@
 
                 if (jsFiles.length > 0) {
                     var jsDeferred = $q.defer();
-                    $delegate.jsLoader(jsFiles, function (err) {
-                        if (angular.isDefined(err) && ($delegate.jsLoader.hasOwnProperty("ocLazyLoadLoader") || $delegate.jsLoader.hasOwnProperty("requirejs"))) {
-                            $delegate._$log.error(err);
-                            jsDeferred.reject(err);
-                        } else {
-                            jsDeferred.resolve();
-                        }
+                    $delegate.jsLoader(jsFiles, function (response) {
+                        jsDeferred.resolve(response);
+                    }, function (err) {
+                        $delegate._$log.error(err);
+                        jsDeferred.reject(err);
                     }, params);
                     promises.push(jsDeferred.promise);
                 }
@@ -1194,8 +1192,8 @@
              * @param params object config parameters
              * because the user can overwrite jsLoader and it will probably not use promises :(
              */
-            $delegate.jsLoader = function (paths, callback, params) {
-                require(paths, callback, callback, params);
+            $delegate.jsLoader = function (paths, callback, erroCallBack, params) {
+                require(paths, callback, erroCallBack, params);
             };
             $delegate.jsLoader.requirejs = true;
 
@@ -1253,64 +1251,64 @@
 })(angular);
 // Array.indexOf polyfill for IE8
 if (!Array.prototype.indexOf) {
-        Array.prototype.indexOf = function (searchElement, fromIndex) {
-                var k;
+    Array.prototype.indexOf = function (searchElement, fromIndex) {
+        var k;
 
-                // 1. Let O be the result of calling ToObject passing
-                //    the this value as the argument.
-                if (this == null) {
-                        throw new TypeError('"this" is null or not defined');
-                }
+        // 1. Let O be the result of calling ToObject passing
+        //    the this value as the argument.
+        if (this == null) {
+            throw new TypeError('"this" is null or not defined');
+        }
 
-                var O = Object(this);
+        var O = Object(this);
 
-                // 2. Let lenValue be the result of calling the Get
-                //    internal method of O with the argument "length".
-                // 3. Let len be ToUint32(lenValue).
-                var len = O.length >>> 0;
+        // 2. Let lenValue be the result of calling the Get
+        //    internal method of O with the argument "length".
+        // 3. Let len be ToUint32(lenValue).
+        var len = O.length >>> 0;
 
-                // 4. If len is 0, return -1.
-                if (len === 0) {
-                        return -1;
-                }
+        // 4. If len is 0, return -1.
+        if (len === 0) {
+            return -1;
+        }
 
-                // 5. If argument fromIndex was passed let n be
-                //    ToInteger(fromIndex); else let n be 0.
-                var n = +fromIndex || 0;
+        // 5. If argument fromIndex was passed let n be
+        //    ToInteger(fromIndex); else let n be 0.
+        var n = +fromIndex || 0;
 
-                if (Math.abs(n) === Infinity) {
-                        n = 0;
-                }
+        if (Math.abs(n) === Infinity) {
+            n = 0;
+        }
 
-                // 6. If n >= len, return -1.
-                if (n >= len) {
-                        return -1;
-                }
+        // 6. If n >= len, return -1.
+        if (n >= len) {
+            return -1;
+        }
 
-                // 7. If n >= 0, then Let k be n.
-                // 8. Else, n<0, Let k be len - abs(n).
-                //    If k is less than 0, then let k be 0.
-                k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+        // 7. If n >= 0, then Let k be n.
+        // 8. Else, n<0, Let k be len - abs(n).
+        //    If k is less than 0, then let k be 0.
+        k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
 
-                // 9. Repeat, while k < len
-                while (k < len) {
-                        // a. Let Pk be ToString(k).
-                        //   This is implicit for LHS operands of the in operator
-                        // b. Let kPresent be the result of calling the
-                        //    HasProperty internal method of O with argument Pk.
-                        //   This step can be combined with c
-                        // c. If kPresent is true, then
-                        //    i.  Let elementK be the result of calling the Get
-                        //        internal method of O with the argument ToString(k).
-                        //   ii.  Let same be the result of applying the
-                        //        Strict Equality Comparison Algorithm to
-                        //        searchElement and elementK.
-                        //  iii.  If same is true, return k.
-                        if (k in O && O[k] === searchElement) {
-                                return k;
-                        }
-                        k++;
-                }
-                return -1;
-        };
+        // 9. Repeat, while k < len
+        while (k < len) {
+            // a. Let Pk be ToString(k).
+            //   This is implicit for LHS operands of the in operator
+            // b. Let kPresent be the result of calling the
+            //    HasProperty internal method of O with argument Pk.
+            //   This step can be combined with c
+            // c. If kPresent is true, then
+            //    i.  Let elementK be the result of calling the Get
+            //        internal method of O with the argument ToString(k).
+            //   ii.  Let same be the result of applying the
+            //        Strict Equality Comparison Algorithm to
+            //        searchElement and elementK.
+            //  iii.  If same is true, return k.
+            if (k in O && O[k] === searchElement) {
+                return k;
+            }
+            k++;
+        }
+        return -1;
+    };
 }


### PR DESCRIPTION
I fixed a bug related to requirejs loading (line: 1025 and 1196):
Since most of the time (especially if using TypeScript with AMD) define should return something e.g. 'export class Test' turns to define(...function(){ return  Test;}) the promise was always rejected. The promise should resolve or be rejected according to child result (requirejs). 

Is there any reason to have single call back function rather than function for each case? It also mixes responsibilities, which is anti-pattern.