### PR TITLE
fix(css-loader): ensure CSS loader uses loading patch for PhantomJS 1.9

### DIFF
--- a/src/ocLazyLoad.loaders.common.js
+++ b/src/ocLazyLoad.loaders.common.js
@@ -79,6 +79,7 @@
 
                 /*
                  The event load or readystatechange doesn't fire in:
+                 - PhantomJS 1.9 (headless webkit browser)
                  - iOS < 6       (default mobile browser)
                  - Android < 4.4 (default mobile browser)
                  - Safari < 6    (desktop browser)
@@ -87,15 +88,20 @@
                     if(!uaCssChecked) {
                         var ua = $window.navigator.userAgent.toLowerCase();
 
-                        // iOS < 6
-                        if(/iP(hone|od|ad)/.test($window.navigator.platform)) {
-                            var v = ($window.navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+                        if (ua.indexOf('phantomjs/1.9') > -1) {
+                            // PhantomJS ~1.9
+                            useCssLoadPatch = true;
+                        } else if (/iP(hone|od|ad)/.test($window.navigator.platform)) {
+                            // iOS < 6
+                            var v = $window.navigator.appVersion.match(/OS (\d+)_(\d+)_?(\d+)?/);
                             var iOSVersion = parseFloat([parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)].join('.'));
                             useCssLoadPatch = iOSVersion < 6;
-                        } else if(ua.indexOf("android") > -1) { // Android < 4.4
-                            var androidVersion = parseFloat(ua.slice(ua.indexOf("android") + 8));
+                        } else if (ua.indexOf('android') > -1) {
+                            // Android < 4.4
+                            var androidVersion = parseFloat(ua.slice(ua.indexOf('android') + 8));
                             useCssLoadPatch = androidVersion < 4.4;
-                        } else if(ua.indexOf('safari') > -1) {
+                        } else if (ua.indexOf('safari') > -1) {
+                            // Safari < 6
                             var versionMatch = ua.match(/version\/([\.\d]+)/i);
                             useCssLoadPatch = (versionMatch && versionMatch[1] && parseFloat(versionMatch[1]) < 6);
                         }


### PR DESCRIPTION
Hey @ocombe - Noticed today while trying to get PhantomCSS (which relies on Phantom 1.9.x) setup for our single page app, that the CSS loader promises never completed. Seems like Phantom 1.9.x is also subject to the same `readystatechange` / event loading issues that other WebKit variants suffer from. This fixes that!