### PR TITLE
Fixes hot reloading via systemjs-hot-reloader

### DIFF
--- a/src/ocLazyLoad.core.js
+++ b/src/ocLazyLoad.core.js
@@ -709,6 +709,16 @@
 
     var bootstrapFct = angular.bootstrap;
     angular.bootstrap = function(element, modules, config) {
+        // Clean state from previous bootstrap
+        regModules = ['ng', 'oc.lazyLoad'];
+        regInvokes = {};
+        regConfigs = [];
+        modulesToLoad = [];
+        realModules = [];
+        recordDeclarations = [];
+        broadcast = angular.noop;
+        runBlocks = {};
+        justLoaded = [];
         // we use slice to make a clean copy
         angular.forEach(modules.slice(), module => {
             _addToLoadList(module, true, true);


### PR DESCRIPTION
JSPM/SystemJS allows for hot module reloads via https://github.com/capaj/systemjs-hot-reloader. To get angular to see any module changes angular needs to be bootstrapped again. This can be achieved by save a copy of the original bootstrapped element before bootstrapping occurred. The current bootstrapped element then needs to be removed and replaced with another copy of the original. Once a fresh element is in place, angular.bootstrap can be called again and all changes should show.

When using ocLazyLoad to wire up modules loaded by JSPM this approach doesn't work. The reason is that ocLazyLoad keeps track of what angular modules have already been loaded and prevents them from being loaded again. This PR resets this state every time angular is bootstrapped so that modules will be wired up again after bootstrapping angular for a 2nd time. 