### PR TITLE
Provide the loader with created elements

### DIFF
--- a/dist/modules/ocLazyLoad.loaders.common.js
+++ b/dist/modules/ocLazyLoad.loaders.common.js
@@ -60,7 +60,7 @@
                     el.onload = el['onreadystatechange'] = null;
                     loaded = 1;
                     $delegate._broadcast('ocLazyLoad.fileLoaded', path);
-                    deferred.resolve();
+                    deferred.resolve(el);
                 };
                 el.onerror = function () {
                     filesCache.remove(path);

--- a/dist/ocLazyLoad.js
+++ b/dist/ocLazyLoad.js
@@ -866,7 +866,7 @@
                     el.onload = el['onreadystatechange'] = null;
                     loaded = 1;
                     $delegate._broadcast('ocLazyLoad.fileLoaded', path);
-                    deferred.resolve();
+                    deferred.resolve(el);
                 };
                 el.onerror = function () {
                     filesCache.remove(path);

--- a/src/ocLazyLoad.loaders.common.js
+++ b/src/ocLazyLoad.loaders.common.js
@@ -60,7 +60,7 @@
                     el.onload = el['onreadystatechange'] = null;
                     loaded = 1;
                     $delegate._broadcast('ocLazyLoad.fileLoaded', path);
-                    deferred.resolve();
+                    deferred.resolve(el);
                 };
                 el.onerror = function() {
                     filesCache.remove(path);


### PR DESCRIPTION
Your loader decorators are very straight forward and can be overridden for custom purpose.
But I miss the possibility to get access to the elements created by buildElement.

It would be great if you could accept this request with my little change.