### PR TITLE
Added scriptType and defaultScriptType

### DIFF
--- a/dist/modules/ocLazyLoad.core.js
+++ b/dist/modules/ocLazyLoad.core.js
@@ -28,7 +28,8 @@
             debug = false,
             events = false,
             moduleCache = [],
-            modulePromises = {};
+            modulePromises = {},
+            defaultScriptType = 'application/javascript';
 
         moduleCache.push = function (value) {
             if (this.indexOf(value) === -1) {
@@ -54,6 +55,10 @@
 
             if (angular.isDefined(config.events)) {
                 events = config.events;
+            }
+
+            if (angular.isDefined(config.defaultScriptType)) {
+                defaultScriptType = config.defaultScriptType;
             }
         };
 

--- a/dist/modules/ocLazyLoad.loaders.common.js
+++ b/dist/modules/ocLazyLoad.loaders.common.js
@@ -48,6 +48,7 @@
                         break;
                     case 'js':
                         el = $window.document.createElement('script');
+                        el.type = angular.isDefined(params.scriptType) ? params.scriptType : this.getDefaultScriptType();
                         el.src = params.cache === false ? cacheBuster(path) : path;
                         break;
                     default:


### PR DESCRIPTION
By default, ocLazyLoad doesn't add type attribute to script tag. This led to an error when loading js file with 'yield' using FireFox, specifically the error is 'SyntaxError: yield is a reserved identifier'.

To let FireFox correctly recognize the js file, I need to put type type="application/javascript;version=1.8" in script tag.

Now you can set the default script type attribute by configuration with

```JavaScript
angular.module('app', ['oc.lazyLoad']).config(['$ocLazyLoadProvider', function($ocLazyLoadProvider) {
  $ocLazyLoadProvider.config({
    defaultScriptType: 'application/javascript;version=1.8'
  });
}]);
```

or directly with your router

```JavaScript
$routerProvider.when('/MyCtrl', {
  templateUrl: 'views/MyView.html',
  controller: 'MyCtrl',
  resolve: {
    lazy: ['$ocLazyLoad', function ($ocLazyLoad) {
      return $ocLazyLoad.load([{
        name: 'MyCtrl',
        files: ['scripts/controllers/MyCtrl.js'],
        scriptType: 'application/javascript;version=1.8'
      }]);
    }]
  }
})
```