### PR TITLE
add simple commonjs support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/ocLazyLoad.js');
+module.exports = 'oc.lazyLoad';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oclazyload",
   "version": "1.0.9",
   "description": "Load modules on demand (lazy load) with angularJS",
-  "main": "index.js
+  "main": "index.js",
   "author": "Olivier Combe <olivier.combe@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/ocombe/ocLazyLoad",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oclazyload",
   "version": "1.0.9",
   "description": "Load modules on demand (lazy load) with angularJS",
-  "main": "dist/ocLazyLoad.js",
+  "main": "index.js
   "author": "Olivier Combe <olivier.combe@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/ocombe/ocLazyLoad",


### PR DESCRIPTION
so we can use the module properly via browserify/webpack. this is the angular recommended way (practiced by angular itsself)